### PR TITLE
Fix typo causing errors when updating child device tilt level

### DIFF
--- a/SunsaWands/SunsaWandsAPI.groovy
+++ b/SunsaWands/SunsaWandsAPI.groovy
@@ -224,7 +224,7 @@ private def setTiltLevelResponse( resp, data ){
                 //def dni = Data.device.idDevivce.toString();
                 //dni = "${device.deviceNetworkId}-${dni}"
                 
-                def dni = "${device.deviceNetworkId}-${Data.device.idDevivce}";
+                def dni = "${device.deviceNetworkId}-${Data.device.idDevice}";
                 
                 logInfo(dni);
                 

--- a/SunsaWands/packageManifest.json
+++ b/SunsaWands/packageManifest.json
@@ -7,7 +7,7 @@
     "licenseFile": "https://raw.githubusercontent.com/dcaton/Hubitat/main/SunsaWands/LICENSE",
     "releaseNotes": "Bug fix, restored WindowShade capability until omission is fixed in HE",
     "documentationLink": "https://raw.githubusercontent.com/dcaton/Hubitat/main/SunsaWands/README.md",
-    "communityLink": "",
+    "communityLink": "https://community.hubitat.com/t/sunsa-wand-simple-smart-blinds/63900",
     "drivers": [
     {
       "id": "c3c4553e-e56f-4910-961a-7c42bca11744",


### PR DESCRIPTION
This PR contains two proposed changes:

1. Fixing a typo which was causing the `dni` to be broken, causing a `refresh` more often than needed.
2. Linking to the original Hubitat Community thread that mentions this driver.

The second change is optional, but please strongly consider merging in at least the first one.

I verified locally that making this change no longer shows the error when opening and/or closing the blinds.