### PR TITLE
Support vertical blinds

### DIFF
--- a/SunsaWands/SunsaWandsChild.groovy
+++ b/SunsaWands/SunsaWandsChild.groovy
@@ -42,7 +42,7 @@ metadata {
 }
 
 preferences {
-    input(name: "closeDirection", type: "enum", options: ["Up", "Down"], title: "Close Direction", description: "", required: true, defaultValue: "Up")
+    input(name: "closeDirection", type: "enum", options: ["Up", "Down", "Left", "Right"], title: "Close Direction", description: "", required: true, defaultValue: "Up")
 }
 
 void installed() {
@@ -64,7 +64,7 @@ void open() {
 }
 
 void close() {
-     setTiltLevel(settings.closeDirection == "Down" ? 100 : -100);
+     setTiltLevel(settings.closeDirection in ["Down", "Right"] ? 100 : -100);
 }
 
 void setPosition(position) { log.warn "setPosition() not applicable to this device"; }


### PR DESCRIPTION
Since `Up` is equivalent to `Left` and `Right` is equivalent to `Down` for vertical and horizontal blinds, respectively, this change only needs to update the child devices to show the new options. The Sunsa API operates on numbers like `-100` to `100` anyway.

I validated with both my vertical and horizontal blinds that they still open and close as expected using all 4 options of `Left`, `Right`, `Up`, and `Down`.